### PR TITLE
Add support for Fedora.

### DIFF
--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -37,6 +37,8 @@ module OmnibusTrucker
       unless(@attrs)
         if(set[:platform] == 'amazon')
           @attrs = {:platform => 'el', :platform_version => 6}
+        elsif(set[:platform_family] == 'fedora')
+          @attrs = {:platform => 'el', :platform_version => 6}
         elsif(set[:platform_family] == 'rhel')
           @attrs = {:platform => 'el', :platform_version => set[:platform_version].to_i}
         elsif(set[:platform] == 'debian')

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "chrisroberts.code@gmail.com"
 license          "Apache 2.0"
 description      "Chef omnibus package updater and installer"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.0"
+version          "1.0.1"


### PR DESCRIPTION
Fedora should be recognized as an Enterprise Linux platform. Simple fix.