### PR TITLE
Add optional checksum to the remote_file resource for file integrity.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,3 +9,4 @@ default[:omnibus_updater][:kill_chef_on_upgrade] = true
 default[:omnibus_updater][:always_download] = false
 default[:omnibus_updater][:prevent_downgrade] = false
 default[:omnibus_updater][:restart_chef_service] = false
+default[:omnibus_updater][:checksum] = nil

--- a/recipes/downloader.rb
+++ b/recipes/downloader.rb
@@ -20,6 +20,7 @@ if(remote_path)
     path File.join(node[:omnibus_updater][:cache_dir], File.basename(remote_path))
     source remote_path
     backup false
+    checksum node[:omnibus_updater][:checksum] if node[:omnibus_updater][:checksum]
     action :create_if_missing
     only_if do
       unless(version = node[:omnibus_updater][:version])


### PR DESCRIPTION
Useful if the file transfer is broken, which has happened to us a few times.