### PR TITLE
exec() chef-client to resume the run after updating the omnibus install

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,21 @@ attribute by setting the `force_latest` attribute.
 Chef Killing
 ------------
 
-By default the omnibus updater will kill the chef instance by raising an exception.
-You can turn this off using the `kill_chef_on_upgrade` attribute. It is not
-recommended to turn this off. Internal chef libraries may change, move, or no
-longer exist. The currently running instance can encounter unexpected states because
-of this. To prevent this, the updater will attempt to kill the Chef instance so
-that it can be restarted in a normal state.
+By default the omnibus updater will re-exec chef to continue the run using the
+new version.  Older versions used to just kill the chef-client and abort the
+run, but exec()ing Chef allows runs to complete without errors being bubbled up
+the stack. You can choose between these behaviors by using the
+`upgrade_behavior` attribute.
+
+* If set to 'kill', the run will be aborted by raising an exception.
+* If set to 'exec', the run will be resumed by re-exec'ing chef-client. This
+  doesn't work in solo mode; when using chef-solo, setting this attribute to
+  'exec' is equivalent to 'kill'. You can customize the command that is exec'd
+  by setting the `exec_command` attribute.
+* If set to anything else, the run is not aborted. Doing this is not
+  recommended. Internal chef libraries may change, move, or no
+  longer exist. The currently running instance can encounter unexpected states
+  because of this, so using 'kill' or 'exec' is highly recommended.
 
 Restart chef-client Service
 ---------------------------
@@ -75,9 +84,9 @@ to a role but should then be skipped for example on a Chef server.
 Prevent Downgrade
 -----------------
 
-If you want to prevent the updater from downgrading chef on a node, you 
+If you want to prevent the updater from downgrading chef on a node, you
 can set the `prevent_downgrade` attribute to true.  This can be useful
-for testing new versions manually.  Note that the `always_download` 
+for testing new versions manually.  Note that the `always_download`
 attribute takes precedence if set.
 
 Infos

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,7 +5,12 @@ default[:omnibus_updater][:cache_omnibus_installer] = false
 default[:omnibus_updater][:remove_chef_system_gem] = false
 default[:omnibus_updater][:prerelease] = false
 default[:omnibus_updater][:disabled] = false
-default[:omnibus_updater][:kill_chef_on_upgrade] = true
+default[:omnibus_updater][:upgrade_behavior] = 'exec'
+default[:omnibus_updater][:upgrade_notification] = :immediately
+default[:omnibus_updater][:exec_command] = 'chef-client'
+# restore the 'classic' behavior with:
+# default[:omnibus_updater][:upgrade_behavior] = 'kill'
+# default[:omnibus_updater][:upgrade_notification] = :delayed
 default[:omnibus_updater][:always_download] = false
 default[:omnibus_updater][:prevent_downgrade] = false
 default[:omnibus_updater][:restart_chef_service] = false

--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -13,15 +13,20 @@ end
 ruby_block 'omnibus chef killer' do
   block do
     upgrade_behavior = node[:omnibus_updater][:upgrade_behavior]
-    if upgrade_behavior == 'exec' and Chef::Config[:solo]
-      Chef::Log.info 'Cannot use omnibus_updater "exec" upgrade behavior in solo mode -- changing to "kill".'
-      upgrade_behavior = 'kill'
+    if upgrade_behavior == 'exec'
+      if Chef::Config[:solo] or Chef::Config.local_mode
+        Chef::Log.info 'Cannot use omnibus_updater "exec" upgrade behavior in solo/local mode -- changing to "kill".'
+        upgrade_behavior = 'kill'
+      elsif not RbConfig::CONFIG['host_os'].start_with?('linux')
+        Chef::Log.info 'omnibus_updater "exec" upgrade behavior only supported on Linux -- changing to "kill".'
+        upgrade_behavior = 'kill'
+      end
     end
 
     case upgrade_behavior
       when 'exec'
         Chef::Log.info 'Replacing ourselves with the new version of Chef to continue the run.'
-        exec(node[:omnibus_updater][:exec_command])
+        exec(node[:omnibus_updater][:exec_command], *ARGV)
       when 'kill'
         raise 'New version of Chef omnibus installed. Aborting the Chef run, please restart it manually.'
       else
@@ -44,18 +49,10 @@ execute "omnibus_install[#{File.basename(remote_path)}]" do
   else
     raise "Unknown package type encountered for install: #{File.extname(remote_path)}"
   end
-  action :nothing
   if(node[:omnibus_updater][:restart_chef_service])
     notifies :restart, resources(:service => 'chef-client'), :immediately
   end
   notifies :create, resources(:ruby_block => 'omnibus chef killer'), :immediately
-end
-
-ruby_block 'Omnibus Chef install notifier' do
-  block{ true }
-  action :nothing
-  subscribes :create, resources(:remote_file => "omnibus_remote[#{File.basename(remote_path)}]"), :immediately
-  notifies :run, resources(:execute => "omnibus_install[#{File.basename(remote_path)}]"), node[:omnibus_updater][:upgrade_notification]
   only_if { node['chef_packages']['chef']['version'] != node['omnibus_updater']['version'] }
 end
 

--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -12,12 +12,23 @@ end
 
 ruby_block 'omnibus chef killer' do
   block do
-    raise 'New omnibus chef version installed. Killing Chef run!'
+    upgrade_behavior = node[:omnibus_updater][:upgrade_behavior]
+    if upgrade_behavior == 'exec' and Chef::Config[:solo]
+      Chef::Log.info 'Cannot use omnibus_updater "exec" upgrade behavior in solo mode -- changing to "kill".'
+      upgrade_behavior = 'kill'
+    end
+
+    case upgrade_behavior
+      when 'exec'
+        Chef::Log.info 'Replacing ourselves with the new version of Chef to continue the run.'
+        exec(node[:omnibus_updater][:exec_command])
+      when 'kill'
+        raise 'New version of Chef omnibus installed. Aborting the Chef run, please restart it manually.'
+      else
+        raise "Unexpected upgrade behavior: #{node[:omnibus_updater][:upgrade_behavior]}"
+    end
   end
   action :nothing
-  only_if do
-    node[:omnibus_updater][:kill_chef_on_upgrade]
-  end
 end
 
 execute "omnibus_install[#{File.basename(remote_path)}]" do
@@ -44,7 +55,7 @@ ruby_block 'Omnibus Chef install notifier' do
   block{ true }
   action :nothing
   subscribes :create, resources(:remote_file => "omnibus_remote[#{File.basename(remote_path)}]"), :immediately
-  notifies :run, resources(:execute => "omnibus_install[#{File.basename(remote_path)}]"), :delayed
+  notifies :run, resources(:execute => "omnibus_install[#{File.basename(remote_path)}]"), node[:omnibus_updater][:upgrade_notification]
   only_if { node['chef_packages']['chef']['version'] != node['omnibus_updater']['version'] }
 end
 

--- a/test/kitchen/cookbooks/omnibus_updater_test/recipes/default.rb
+++ b/test/kitchen/cookbooks/omnibus_updater_test/recipes/default.rb
@@ -1,3 +1,3 @@
-node.set[:omnibus_updater][:kill_chef_on_upgrade] = false
+node.set[:omnibus_updater][:upgrade_behavior] = nil
 node.set[:omnibus_updater][:version] = false
 include_recipe "omnibus_updater"

--- a/test/kitchen/cookbooks/omnibus_updater_test/recipes/version_upgrade.rb
+++ b/test/kitchen/cookbooks/omnibus_updater_test/recipes/version_upgrade.rb
@@ -1,3 +1,3 @@
 node.set[:omnibus_updater][:version] = '11.16'
-node.set[:omnibus_updater][:kill_chef_on_upgrade] = false
+node.set[:omnibus_updater][:upgrade_behavior] = nil
 include_recipe "omnibus_updater"


### PR DESCRIPTION
Rather than kill the chef client and leave it to the user to pick up the
pieces and, in most cases, simply resume the run, do that by default by
exec'ing chef-client again in the ruby_block to start using the new
version.

The original behavior is still accessible via attributes.