### PR TITLE
Add windows support through windows scheduled tasks

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default[:omnibus_updater][:version] = nil
 default[:omnibus_updater][:force_latest] = false
-default[:omnibus_updater][:cache_dir] = '/opt'
+default[:omnibus_updater][:cache_dir] = Chef::Config[:file_cache_path]
 default[:omnibus_updater][:cache_omnibus_installer] = false
 default[:omnibus_updater][:remove_chef_system_gem] = false
 default[:omnibus_updater][:prerelease] = false
@@ -10,3 +10,25 @@ default[:omnibus_updater][:always_download] = false
 default[:omnibus_updater][:prevent_downgrade] = false
 default[:omnibus_updater][:restart_chef_service] = false
 default[:omnibus_updater][:checksum] = nil
+default[:omnibus_updater][:win_versions] = {
+    6.3 => {
+        :os_name => "Windows Server 2012 R2",
+        :os_omnibus_name => "2012"
+    },
+    6.2 => {
+        :os_name => "Windows Server 2012",
+        :os_omnibus_name => "2012"
+    },
+    6.1 => {
+        :os_name => "Windows Server 2008 R2",
+        :os_omnibus_name => "2008r2"
+    },
+    6.0 => {
+        :os_name => "Windows Server 2008",
+        :os_omnibus_name => "2008"
+    },
+    5.2 => {
+        :os_name => "Windows Server 2003 R2",
+        :os_omnibus_name => "2003r2"
+    }
+}

--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -45,6 +45,9 @@ module OmnibusTrucker
           @attrs = {:platform => set[:platform], :platform_version => set[:platform_version].to_i}
         elsif(set[:platform_family] == 'mac_os_x')
           @attrs = {:platform => set[:platform_family], :platform_version => [set[:platform_version].to_f, 10.7].min}
+        elsif(set[:platform_family] == 'windows')
+          platform_version = node[:omnibus_updater][:win_versions][set[:platform_version][0..2].to_f][:os_omnibus_name]
+          @attrs = {:platform => set[:platform_family], :platform_version => platform_version}
         else
           @attrs = {:platform => set[:platform], :platform_version => set[:platform_version]}
         end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,3 +5,4 @@ license          "Apache 2.0"
 description      "Chef omnibus package updater and installer"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.0.2"
+depends          "windows"

--- a/recipes/downloader.rb
+++ b/recipes/downloader.rb
@@ -24,16 +24,16 @@ if(remote_path)
     action :create_if_missing
     only_if do
       unless(version = node[:omnibus_updater][:version])
-        version = node[:omnibus_updater][:full_url].scan(%r{chef[_-](\d+\.\d+.\d+)}).flatten.first
+        version = node[:omnibus_updater][:full_url].scan(%r{chef(-windows)[_-](\d+\.\d+.\d+)}).flatten[1]
       end
-      if(node[:omnibus_updater][:always_download])
+      if (node[:omnibus_updater][:always_download] and not platform?('windows'))
         # warn if there may be unexpected behavior
         node[:omnibus_updater][:prevent_downgrade] &&
           Chef::Log.warn("omnibus_updater: prevent_downgrade is ignored when always_download is true")
         Chef::Log.debug "Omnibus Updater remote path: #{remote_path}"
         true
-      elsif(node[:omnibus_updater][:prevent_downgrade])
-        # Return true if the found/specified version is newer
+      elsif node[:omnibus_updater][:prevent_downgrade] or platform?('windows')
+        # Return true if the found/specified version is newer (no support for downgrade in windows yet...)
         Gem::Version.new(version.to_s.sub(/\-.+$/, '')) > Gem::Version.new(Chef::VERSION)
       else
         # default is to install if the versions don't match

--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -30,6 +30,8 @@ execute "omnibus_install[#{File.basename(remote_path)}]" do
     command "/bin/sh #{File.join(node[:omnibus_updater][:cache_dir], File.basename(remote_path))}"
   when '.solaris'
     command "pkgadd -n -d #{File.join(node[:omnibus_updater][:cache_dir], File.basename(remote_path))} -a /tmp/nocheck chef"
+  when '.msi'
+    # Do not raise exception, the installation will be triggered in the sched-task resource
   else
     raise "Unknown package type encountered for install: #{File.extname(remote_path)}"
   end
@@ -40,11 +42,48 @@ execute "omnibus_install[#{File.basename(remote_path)}]" do
   notifies :create, resources(:ruby_block => 'omnibus chef killer'), :immediately
 end
 
+template "#{Chef::Config[:file_cache_path]}/upgrade_chef_client.bat" do
+  source 'upgrade_chef_client.bat.erb'
+  variables({
+                "msi_installer" => "c:#{File.join(node[:omnibus_updater][:cache_dir], File.basename(remote_path)).gsub('/','\\')}"
+            })
+  action :nothing
+end
+
+ruby_block "omnibus_install_windows[#{File.basename(remote_path)}]" do
+  block do
+    # Stops the chef-client service
+    notifies :stop, resources(:service => 'chef-client'), :immediately
+    # Creates a bat file to be run in a scheduled task
+    notifies :create, resources(:template => "#{Chef::Config[:file_cache_path]}/upgrade_chef_client.bat"), :immediately
+    # Remove the scheduled task (in case it is not the first time it is upgraded)
+    notifies :remove, resources(:windows_task => 'Update chef-client'), :immediately
+    # Adds a scheduled task to be run once in 10 minutes
+    notifies :create, resources(:windows_task => 'Update chef-client'), :immediately
+    # Kills the current chef-client execution
+    notifies :create, resources(:ruby_block => 'omnibus chef killer'), :immediately
+  end
+  action :nothing
+end
+
+#Instead of scheduling for 600 seconds after chef compile time, we should get current time during task execution
+windows_task "Update chef-client" do
+  action :nothing
+  command "#{Chef::Config[:file_cache_path]}/upgrade_chef_client.bat > #{Chef::Config[:file_cache_path]}/upgrade_chef_client.log"
+  start_day (Time.now + 600).strftime("%d/%m/%Y")
+  start_time (Time.now + 600).strftime("%H:%M")
+  frequency :once
+end
+
 ruby_block 'Omnibus Chef install notifier' do
   block{ true }
   action :nothing
   subscribes :create, resources(:remote_file => "omnibus_remote[#{File.basename(remote_path)}]"), :immediately
-  notifies :run, resources(:execute => "omnibus_install[#{File.basename(remote_path)}]"), :delayed
+  if platform?('windows')
+    notifies :run, resources(:ruby_block => "omnibus_install_windows[#{File.basename(remote_path)}]"), :delayed
+  else
+    notifies :run, resources(:execute => "omnibus_install[#{File.basename(remote_path)}]"), :delayed
+  end
   only_if { node['chef_packages']['chef']['version'] != node['omnibus_updater']['version'] }
 end
 

--- a/templates/default/upgrade_chef_client.bat.erb
+++ b/templates/default/upgrade_chef_client.bat.erb
@@ -1,0 +1,7 @@
+@ECHO OFF
+net stop chef-client
+REM Do not capture errors when stopping chef, as it could be already stopped and that will return error
+msiexec.exe /quiet /passive /package "<%= @msi_installer %>" ADDLOCAL="ChefClientFeature,ChefServiceFeature"
+<% if node[:omnibus_updater][:restart_chef_service] and @zabbix_server -%>
+net start chef-client
+<% end -%>


### PR DESCRIPTION
I needed to support chef-client updates on windows and I get from IRC channel for chef that in last chef summit the discussion pointed that this should be done through scheduled tasks.
I have gave it a try.
One thing I have not been able to workaround is the windows dependency on the metadata, as if you are using omnibus updater for linux, this has no sense, but I cannot find how to do conditional dependencies.

Modified the cookbook to only upgrade windows (msi installer does not support downgrade, although it could be achieved deleting current version and installing new one)