### PR TITLE
Avoid deleting chef-server packages if using the same cache dir

### DIFF
--- a/recipes/old_package_cleaner.rb
+++ b/recipes/old_package_cleaner.rb
@@ -29,5 +29,6 @@ old_pkgs =
 old_pkgs.each do |filename|
   file filename do
     action :delete
+    backup 1
   end
 end

--- a/recipes/old_package_cleaner.rb
+++ b/recipes/old_package_cleaner.rb
@@ -19,7 +19,7 @@
 
 old_pkgs =
   if(::File.exist?(node[:omnibus_updater][:cache_dir]))
-    Dir.glob(File.join(node[:omnibus_updater][:cache_dir], 'chef*')).find_all do |file|
+    Dir.glob(File.join(node[:omnibus_updater][:cache_dir], 'chef_*')).find_all do |file|
       !file.include?(node[:omnibus_updater][:version].to_s) && !file.scan(/\.(rpm|deb)$/).empty?
     end
   else


### PR DESCRIPTION
If the user sets the cache dir to be Chef's cache dir (makes sense right?) then omnibus_updater attempts to delete the chef server installer on each run.  This creates two issues:
- You waste time downloading the chef server package every chef run (pretty big)
- Chef backs up the deb 5 times and fills up your disk