### PR TITLE
Fixed machine attribute for Solaris Sparc

### DIFF
--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -67,8 +67,13 @@ module OmnibusTrucker
         else
           @attrs = {:platform => set[:platform], :platform_version => set[:platform_version]}
         end
-        @attrs[:machine] = args[:machine] || node[:kernel][:machine]
-        @attrs[:machine] = "i386" if(set[:platform_family] == 'solaris2' && @attrs[:machine] == "i86pc")
+        if(args[:machine])
+          @attrs[:machine] = args[:machine]
+        elsif(set[:platform_family] == 'solaris2')
+          @attrs[:machine] = (node[:kernel][:machine] == 'i86pc' ? 'i386' : 'sparc')
+        else
+          @attrs[:machine] = node[:kernel][:machine]
+        end
       end
       @attrs
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "chrisroberts.code@gmail.com"
 license          "Apache 2.0"
 description      "Chef omnibus package updater and installer"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.4"
+version          "1.0.5"

--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -21,7 +21,7 @@ include_recipe 'omnibus_updater'
 remote_path = node[:omnibus_updater][:full_url].to_s
 
 file '/tmp/nocheck' do
-  content 'conflict=nocheck\naction=nocheck'
+  content "conflict=nocheck\naction=nocheck\ninstance=overwrite"
   only_if { node['os'] =~ /^solaris/ }
 end
 


### PR DESCRIPTION
My Solaris 11.x Sparc machines report `sun4u` as `kernel.machine`, but the download URL expects `sparc`.

```
#knife search node platform:solaris2 -a kernel.machine
3 items found

sparc_1:
  kernel.machine: sun4v

x86_1:
  kernel.machine: i86pc

sparc_2:
  kernel.machine: sun4v
```

```
#curl -v "http://www.opscode.com/chef/download?p=solaris2&pv=5.11&m=sun4u&v=12.2.1"
* Hostname was NOT found in DNS cache
*   Trying 166.78.227.233...
* Connected to www.opscode.com (166.78.227.233) port 80 (#0)
> GET /chef/download?p=solaris2&pv=5.11&m=sun4u&v=12.2.1 HTTP/1.1
> User-Agent: curl/7.39.0
> Host: www.opscode.com
> Accept: */*
>
< HTTP/1.1 404 Not Found
< Server: ngx_openresty
< Date: Thu, 23 Apr 2015 12:38:47 GMT
< Content-Type: text/html;charset=utf-8
< Content-Length: 0
< Connection: keep-alive
< Status: 404 Not Found
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
<
* Connection #0 to host www.opscode.com left intact

#curl -v "http://www.opscode.com/chef/download?p=solaris2&pv=5.11&m=sparc&v=12.2.1"
* Hostname was NOT found in DNS cache
*   Trying 166.78.227.233...
* Connected to www.opscode.com (166.78.227.233) port 80 (#0)
> GET /chef/download?p=solaris2&pv=5.11&m=sparc&v=12.2.1 HTTP/1.1
> User-Agent: curl/7.39.0
> Host: www.opscode.com
> Accept: */*
>
< HTTP/1.1 302 Found
< Server: ngx_openresty
< Date: Thu, 23 Apr 2015 12:38:50 GMT
< Content-Type: text/html;charset=utf-8
< Content-Length: 0
< Connection: keep-alive
< Status: 302 Found
< Location: http://opscode-omnibus-packages.s3.amazonaws.com/solaris2/5.9/sparc/chef-12.2.1-1.sun4u.solaris
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
<
* Connection #0 to host www.opscode.com left intact
```