### PR TITLE
if amazon linux uninstall package before upgrading to make sure bin stubs

### DIFF
--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -75,7 +75,11 @@ else
       when '.deb'
         command "dpkg -i #{File.join(node[:omnibus_updater][:cache_dir], File.basename(remote_path))}"
       when '.rpm'
-        command "rpm -Uvh --oldpackage #{File.join(node[:omnibus_updater][:cache_dir], File.basename(remote_path))}"
+        if node['platform'] == 'amazon'
+          command "rpm -e chef && rpm -Uvh --oldpackage #{File.join(node[:omnibus_updater][:cache_dir], File.basename(remote_path))}"
+        else
+          command "rpm -Uvh --oldpackage #{File.join(node[:omnibus_updater][:cache_dir], File.basename(remote_path))}"
+        end
       when '.sh'
         command "/bin/sh #{File.join(node[:omnibus_updater][:cache_dir], File.basename(remote_path))}"
       when '.solaris'


### PR DESCRIPTION
Amazon Linux: uninstall package before upgrading to make sure bin stubs are in place.

Chef rpm packages have an issue on amazon where rpm upgrades from previous chef version can cause /usr/bin/chef-client and other bin stub links to not be created properly. 