### PR TITLE
Don't try to run on Raspbian OS

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,6 +21,8 @@ if(node[:omnibus_updater][:disabled])
   Chef::Log.warn 'Omnibus updater disabled via `disabled` attribute'
 elsif(node[:platform] == 'debian' && Gem::Version.new(node[:platform_version]) < Gem::Version.new('6.0.0'))
   Chef::Log.warn 'Omnibus updater does not support Debian 5'
+elsif(node[:platform] == 'raspbian')
+  Chef::Log.warn 'Omnibus updater does not support Raspbian'
 else
   include_recipe 'omnibus_updater::downloader'
   include_recipe 'omnibus_updater::installer'


### PR DESCRIPTION
We use omnibus_updater in our base cookbook that applies to all nodes.  We are bringing some Raspberry Pi devices into Chef management.  Since there is no omnibus package for Raspbian, just need to notify and continue without running omnibus_updater.