### PR TITLE
require chef/rest

### DIFF
--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -18,6 +18,8 @@
 #
 
 require "chef/rest"
+require "chef/mash"
+require "net/http"
 
 module OmnibusTrucker
   class << self

--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -52,7 +52,7 @@ module OmnibusTrucker
     end
 
     def collect_attributes(node, args={})
-      set = Mash[
+      set = Chef::Mash[
         [:platform_family, :platform, :platform_version].map do |k|
           [k, args[k] || node[k]]
         end

--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+require "chef/rest"
+
 module OmnibusTrucker
   class << self
     URL_MAP = {


### PR DESCRIPTION
Chef 12.7+ no longer globally requires 'chef/rest', since it uses Chef::ServerAPI under the hood. So require what we use.

Please can we get this merged and released? cc @webframp @slyness