### PR TITLE
Define the Chef::Mash constant if not provided by chef

### DIFF
--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -21,6 +21,10 @@ require "chef/rest"
 require "chef/mash"
 require "net/http"
 
+unless(Chef.constants.include?(:Mash))
+  Chef::Mash = Mash
+end
+
 module OmnibusTrucker
   class << self
     URL_MAP = {


### PR DESCRIPTION
If the `Chef::Mash` constant does not exist (currently does not in any released
version) a warning will be generated on use due to lookup and usage from root
namespace. This change will define the expected `Chef::Mash` constant only if
it has not already been provided to suppress warnings generated by Ruby.