### PR TITLE
Release 1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+v1.0.6
+======
+* Get rid of warnings about defined constant
+* update Chef download url
+* Updates supported versions
+* require chef/rest
+* use Chef::Mash explicitly
+* Define the Chef::Mash constant if not provided by chef
+* add test suites for ubuntu 14.04 and centos 7
+
 v1.0.4
 ======
 * file_cache_path path to store chef-client

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "chrisroberts.code@gmail.com"
 license          "Apache 2.0"
 description      "Chef omnibus package updater and installer"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.5"
+version          "1.0.6"
 
 supports redhat
 supports centos

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,12 +6,6 @@ description      "Chef omnibus package updater and installer"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.0.6"
 
-supports redhat
-supports centos
-supports amazon
-supports scientific
-supports oracle
-supports debian
-supports ubuntu
-supports mac_os_x
-supporst solaris
+%w(redhat centos amazon scientific oracle debian ubuntu mac_os_x solaris).each do |plat|
+  supports "#{plat}"
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,5 +7,5 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.0.6"
 
 %w(redhat centos amazon scientific oracle debian ubuntu mac_os_x solaris).each do |plat|
-  supports "#{plat}"
+  supports plat
 end


### PR DESCRIPTION
* Get rid of warnings about defined constant
* update Chef download url
* Updates supported versions
* require chef/rest
* use Chef::Mash explicitly
* Define the Chef::Mash constant if not provided by chef
* add test suites for ubuntu 14.04 and centos 7