### PR TITLE
omnibus_updater 1.0.6

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,10 @@
 ---
 driver_plugin: vagrant
 platforms:
+- name: ubuntu-14.04
+  driver_config:
+    require_chef_omnibus: '11.14'
+    box: ubuntu1404
 - name: ubuntu-12.04
   driver_config:
     require_chef_omnibus: '11.14'
@@ -9,6 +13,10 @@ platforms:
   driver_config:
     require_chef_omnibus: '11.14'
     box: ubuntu1004
+- name: centos-7.0
+  driver_config:
+    require_chef_omnibus: '11.14'
+    box: centos70
 - name: centos-6.4
   driver_config:
     require_chef_omnibus: '11.14'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+v1.0.6
+======
+* Get rid of warnings about defined constant
+* update Chef download url
+* Updates supported versions
+* require chef/rest
+* use Chef::Mash explicitly
+* Define the Chef::Mash constant if not provided by chef
+* add test suites for ubuntu 14.04 and centos 7
+
 v1.0.4
 ======
 * file_cache_path path to store chef-client

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supports
 - oracle
 - debian
 - ubuntu
-- max_os_x
+- mac_os_x
 - solaris
 
 Usage

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Chef package into your system if you are currently running
 via gem install, and it can keep your omnibus install up
 to date.
 
+Supports
+========
+
+- redhat
+- centos
+- amazon
+- scientific
+- oracle
+- debian
+- ubuntu
+- max_os_x
+- solaris
+
 Usage
 =====
 

--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -18,6 +18,8 @@
 #
 
 require "chef/rest"
+require "chef/mash"
+require "net/http"
 
 module OmnibusTrucker
   class << self

--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -52,7 +52,7 @@ module OmnibusTrucker
     end
 
     def collect_attributes(node, args={})
-      set = Mash[
+      set = Chef::Mash[
         [:platform_family, :platform, :platform_version].map do |k|
           [k, args[k] || node[k]]
         end

--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -23,7 +23,7 @@ module OmnibusTrucker
       :p => :platform, :pv => :platform_version, :m => :machine,
       :v => :version, :prerelease => :prerelease,
       :nightlies => :nightlies
-    }
+    }  unless defined?(URL_MAP)
 
     def build_url(*opts)
       args = node = nil

--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -21,6 +21,10 @@ require "chef/rest"
 require "chef/mash"
 require "net/http"
 
+unless(Chef.constants.include?(:Mash))
+  Chef::Mash = Mash
+end
+
 module OmnibusTrucker
   class << self
     URL_MAP = {

--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+require "chef/rest"
+
 module OmnibusTrucker
   class << self
     URL_MAP = {

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,3 +5,13 @@ license          "Apache 2.0"
 description      "Chef omnibus package updater and installer"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.0.5"
+
+supports redhat
+supports centos
+supports amazon
+supports scientific
+supports oracle
+supports debian
+supports ubuntu
+supports mac_os_x
+supporst solaris

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,14 +4,8 @@ maintainer_email "chrisroberts.code@gmail.com"
 license          "Apache 2.0"
 description      "Chef omnibus package updater and installer"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.5"
+version          "1.0.6"
 
-supports redhat
-supports centos
-supports amazon
-supports scientific
-supports oracle
-supports debian
-supports ubuntu
-supports mac_os_x
-supporst solaris
+%w(redhat centos amazon scientific oracle debian ubuntu mac_os_x solaris).each do |plat|
+  supports plat
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "chrisroberts.code@gmail.com"
 license          "Apache 2.0"
 description      "Chef omnibus package updater and installer"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.4"
+version          "1.0.5"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,6 +21,8 @@ if(node[:omnibus_updater][:disabled])
   Chef::Log.warn 'Omnibus updater disabled via `disabled` attribute'
 elsif(node[:platform] == 'debian' && Gem::Version.new(node[:platform_version]) < Gem::Version.new('6.0.0'))
   Chef::Log.warn 'Omnibus updater does not support Debian 5'
+elsif(node[:platform] == 'raspbian')
+  Chef::Log.warn 'Omnibus updater does not support Raspbian'
 else
   include_recipe 'omnibus_updater::downloader'
   include_recipe 'omnibus_updater::installer'


### PR DESCRIPTION
* Get rid of warnings about defined constant
* update Chef download url
* Updates supported versions
* require chef/rest
* use Chef::Mash explicitly
* Define the Chef::Mash constant if not provided by chef
* add test suites for ubuntu 14.04 and centos 7