### PR TITLE
Update Test Platforms

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,6 +17,10 @@ platforms:
   driver_config:
     require_chef_omnibus: '11.14'
     box: centos64
+- name: centos-5.11
+  driver_config:
+    require_chef_omnibus: '11.14'
+    box: centos511
 suites:
 - name: default
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,13 @@ platforms:
   driver_config:
     require_chef_omnibus: '11.14'
     box: centos511
+- name: windows-2012r2
+  driver_config:
+    require_chef_omnibus: '11.14'
+    box: windows-2012r2
+  attributes:
+    omnibus_updater:
+    version: 12.5.1
 suites:
 - name: default
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,10 +9,6 @@ platforms:
   driver_config:
     require_chef_omnibus: '11.14'
     box: ubuntu1204
-- name: ubuntu-10.04
-  driver_config:
-    require_chef_omnibus: '11.14'
-    box: ubuntu1004
 - name: centos-7.0
   driver_config:
     require_chef_omnibus: '11.14'
@@ -21,10 +17,6 @@ platforms:
   driver_config:
     require_chef_omnibus: '11.14'
     box: centos64
-- name: centos-5.8
-  driver_config:
-    require_chef_omnibus: '11.14'
-    box: centos58
 suites:
 - name: default
   run_list:

--- a/Cheffile
+++ b/Cheffile
@@ -1,4 +1,4 @@
-site 'http://community.opscode.com/api/v1'
+site 'https://supermarket.chef.io/api/v1'
 
 cookbook 'omnibus_updater', path: './'
 cookbook 'omnibus_updater_test', path: './test/kitchen/cookbooks/omnibus_updater_test'


### PR DESCRIPTION
Remove Ubuntu 10.04 from test suites. Update Centos 5.8 to 5.11. Caveat vintage OS deployer.

Added Windows 2012 (Chef 12.5.1 and under only at this time)